### PR TITLE
1.41

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,43 @@
-# Unofficial Green Pass Android App | A PDF Reader for COVID Certificates (EU Digital COVID  Certificate)
-## Offers a convenient access to a single one-sided PDF document like e.g. a COVID PDF Certificate
+# Green Pass: PDF Reader (unofficial) Android App
+## Offers a convenient access to a single one-sided PDF document and its QR code (if present in the document) like e.g. an EU Digital COVID Certificate
 [Download in Google Play Store](https://play.google.com/store/apps/details?id=com.michaeltroger.gruenerpass) 
 
-Very simple app, that does nothing more than conveniently displaying the "Green Pass". The PDF has to be present already. The Austrian Green Pass is a one-sided PDF document (EU Digital COVID Certificate) that can be downloaded from https://gesundheit.gv.at The reader was optimized for this use-case (Austrian vaccination and test certificate). Other one-sided PDF documents should generally work too though.
+<b>Unofficial app that is fully open source. One one-sided PDF can be imported. If you require to import more than that, then please go for one of the other available solutions. This app is basically a super simple PDF reader for one-sided documents, with convenient fullscreen QR code rendering (if present in the PDF).</b>
 
-The functionality is as follows: The PDF file that you downloaded from https://gesundheit.gv.at has to be imported into the app. Following its first page will be rendered whenever you open the app. That's already it.
-This app assumes you have the PDF certificate from gesundheit.gv.at already on your phone.
+<b>Brief Instruction App Usage</b>
+- Open App
+- Import PDF
+- Done
 
-Does one require this app? Not really. The PDF from gesundheit.gv.at is completely sufficient. The use case for this app is solely the improved usability. 
+<b>Brief Instruction  App Usage 2</b>
+- Open File browser, Email, Browser, Adobe Reader, or a similar app
+- Choose to open/share the PDF with "Green Pass" 
+- Done
 
-Privacy and safety is important! This app doesn't need any permissions. Also no internet connection is required. The document is solely copied to the app's cache and is merely read out for displaying. The document doesn't ever leave the app and can be removed from the cache by the user whenever he/she wishes. No ads, no tracking. The app is fully open source
+<b>Description</b>
+Very simple app, that does nothing more than conveniently displaying the "Green Pass" certificate, from a given PDF file. The PDF has to be present already. In Austria the Green Pass is a one-sided PDF document with QR code (EU Digital COVID Certificate) that can be downloaded from https://gesundheit.gv.at The reader was optimized for this use-case (display of this PDF and its QR code). Other one-sided PDF documents from other authorities should generally work too though, since this app follows a universal approach. 
+
+<b>Functionality</b>
+The Green Pass PDF (EU Digital COVID Certificate) file that you downloaded from https://gesundheit.gv.at or your local authority has to be imported into the app. Following the QR code is displayed in fullscreen (if part of the provided PDF), as well as the PDF itself. That's already it. This app assumes you have the Green Pass PDF certificate (EU Digital COVID Certificate) from gesundheit.gv.at already on your phone. If there is no QR code detected in your PDF, then only the PDF is rendered.
+
+<b>More Features</b>
+- PDFs can be opened and shared from other apps
+- Dark Mode support
+
+<b>Does one require this app?</b>
+Not really. For the Green Pass PDF from gesundheit.gv.at any casual PDF-Reader is completely sufficient. The use case for this app is solely the improved usability. One saves the time for searching the PDF and zooming in for the QR code (if present in the document).
+
+<b>Why offering this app when there is an official one?</b>
+This app was created before an official app was available.
+
+<b>Why does the fullscreen QR code look differently than in the PDF?</b>
+The algorithm to display is different. For reading devices the code is identical.
+
+<b>What is this app doing differently compared to other available approaches?</b>
+One of these approaches requires the Green Pass PDF to be uploaded to a webserver. There the PDF and the QR code are read out and converted into a format, that can be used in so-called Wallet apps. The source code is not available for all solutions. In comparison to that, this app saves time, since the PDF can be imported as it is and it has not to be converted into another format. Further more the file does never leave the app on the respective device and the source code of the app is fully open source.
+
+<b>Privacy</b>
+This app doesn't need any permissions. That also means it has no access to internet etc. The document is solely copied to the app's cache and is merely read out for displaying. The document doesn't ever leave the app, stays locally and offline and can be removed from the cache by the user whenever he/she wishes. No ads, no tracking. The app is fully open source.
 
 <img src="/screenshot.jpg" width="200"> <img src="/screenshot1.jpg" width="200"> <img src="/screenshot2.jpg" width="200">
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,8 +29,8 @@ android {
         applicationId "com.michaeltroger.gruenerpass"
         minSdk 21
         targetSdk 30
-        versionCode 12
-        versionName "1.4"
+        versionCode 13
+        versionName "1.41"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -14,7 +14,7 @@
 
 # Uncomment this to preserve the line number information for
 # debugging stack traces.
-#-keepattributes SourceFile,LineNumberTable
+-keepattributes SourceFile,LineNumberTable
 
 # If you keep the line number information, uncomment this to
 # hide the original source file name.

--- a/app/src/main/java/com/michaeltroger/gruenerpass/MainActivity.kt
+++ b/app/src/main/java/com/michaeltroger/gruenerpass/MainActivity.kt
@@ -6,8 +6,8 @@ import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import androidx.activity.viewModels
 import androidx.core.os.bundleOf
-import androidx.fragment.app.add
 import androidx.fragment.app.commit
+import androidx.fragment.app.replace
 import androidx.lifecycle.ViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 
@@ -20,8 +20,7 @@ class MainActivity : AppCompatActivity(R.layout.activity_main) {
         if (savedInstanceState == null) {
             supportFragmentManager.commit {
                 val bundle = bundleOf(BUNDLE_KEY_URI to intent?.getUri())
-                setReorderingAllowed(true)
-                add<MainFragment>(R.id.fragment_container_view, args = bundle)
+                replace<MainFragment>(R.id.fragment_container_view, args = bundle)
             }
         }
     }

--- a/app/src/main/java/com/michaeltroger/gruenerpass/MainFragment.kt
+++ b/app/src/main/java/com/michaeltroger/gruenerpass/MainFragment.kt
@@ -49,11 +49,6 @@ class MainFragment : Fragment(R.layout.fragment_main) {
         }
     }
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        adapter = PagerAdapter(this)
-    }
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
@@ -64,6 +59,7 @@ class MainFragment : Fragment(R.layout.fragment_main) {
         tabLayout = view.findViewById(R.id.tab_layout)
         addButton = view.findViewById(R.id.add)
 
+        adapter = PagerAdapter(this)
         layoutMediator = TabLayoutMediator(tabLayout!!, viewPager!!) { tab, position ->
             val textRes: Int
             when (adapter.itemCount) {

--- a/app/src/main/java/com/michaeltroger/gruenerpass/pdf/PdfHandler.kt
+++ b/app/src/main/java/com/michaeltroger/gruenerpass/pdf/PdfHandler.kt
@@ -89,12 +89,12 @@ object PdfHandler {
     }
 
     private fun extractQrCodeIfAvailable(bitmap: Bitmap) {
-        val intArray = IntArray(bitmap.width * bitmap.height)
-        bitmap.getPixels(intArray, 0, bitmap.width, 0, 0, bitmap.width, bitmap.height)
-        val source: LuminanceSource = RGBLuminanceSource(bitmap.width, bitmap.height, intArray)
-        val binaryBitmap = BinaryBitmap(HybridBinarizer(source))
-
         try {
+            val intArray = IntArray(bitmap.width * bitmap.height)
+            bitmap.getPixels(intArray, 0, bitmap.width, 0, 0, bitmap.width, bitmap.height)
+            val source: LuminanceSource = RGBLuminanceSource(bitmap.width, bitmap.height, intArray)
+            val binaryBitmap = BinaryBitmap(HybridBinarizer(source))
+
             qrCodeReader.decode(binaryBitmap).text?.let {
                 encodeQrCodeAsBitmap(it)
             }

--- a/app/src/main/java/com/michaeltroger/gruenerpass/pdf/PdfHandler.kt
+++ b/app/src/main/java/com/michaeltroger/gruenerpass/pdf/PdfHandler.kt
@@ -85,6 +85,9 @@ object PdfHandler {
         }
 
         bitmapDocument = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)!!
+        if (bitmapDocument!!.byteCount > MAX_BITMAP_SIZE) {
+            bitmapDocument = Bitmap.createBitmap(page.width, page.height, Bitmap.Config.ARGB_8888)!!
+        }
         val canvas = Canvas(bitmapDocument!!)
         canvas.drawColor(Color.WHITE)
         canvas.drawBitmap(bitmapDocument!!, 0f, 0f, null)

--- a/app/src/main/java/com/michaeltroger/gruenerpass/pdf/PdfHandler.kt
+++ b/app/src/main/java/com/michaeltroger/gruenerpass/pdf/PdfHandler.kt
@@ -19,7 +19,6 @@ import android.graphics.Color
 import com.tom_roush.pdfbox.pdmodel.PDDocument
 import com.tom_roush.pdfbox.pdmodel.encryption.InvalidPasswordException
 import android.graphics.Canvas
-import java.io.FileDescriptor
 
 
 const val PDF_FILENAME = "certificate.pdf"
@@ -29,7 +28,9 @@ private const val MULTIPLIER_PDF_RESOLUTION = 2
 object PdfHandler {
 
     private val context = GreenPassApplication.instance
-    private val activityManager = context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
+    private val activityManager: ActivityManager? by lazy {
+        context.getSystemService(Context.ACTIVITY_SERVICE) as? ActivityManager
+    }
 
     private val qrCodeReader = QRCodeReader()
     private val qrCodeWriter = MultiFormatWriter()
@@ -77,7 +78,7 @@ object PdfHandler {
 
         var width: Int = page.width
         var height: Int = page.height
-        if (!activityManager.isLowRamDevice) {
+        if (activityManager?.isLowRamDevice == false) {
             width *= MULTIPLIER_PDF_RESOLUTION
             height *= MULTIPLIER_PDF_RESOLUTION
         }

--- a/app/src/main/java/com/michaeltroger/gruenerpass/pdf/PdfHandler.kt
+++ b/app/src/main/java/com/michaeltroger/gruenerpass/pdf/PdfHandler.kt
@@ -24,6 +24,7 @@ import android.graphics.Canvas
 const val PDF_FILENAME = "certificate.pdf"
 private const val QR_CODE_SIZE = 400
 private const val MULTIPLIER_PDF_RESOLUTION = 2
+private const val MAX_BITMAP_SIZE = 100 * 1024 * 1024
 
 object PdfHandler {
 
@@ -92,6 +93,12 @@ object PdfHandler {
         page.close()
         renderer.close()
         fileDescriptor.close()
+
+        val bitmapSize: Int = bitmapDocument!!.byteCount
+        if (bitmapSize > MAX_BITMAP_SIZE) {
+            deleteFile()
+            return@withContext false
+        }
 
         extractQrCodeIfAvailable(bitmapDocument!!)
         return@withContext true

--- a/app/src/main/java/com/michaeltroger/gruenerpass/pdf/PdfHandler.kt
+++ b/app/src/main/java/com/michaeltroger/gruenerpass/pdf/PdfHandler.kt
@@ -90,12 +90,13 @@ object PdfHandler {
         canvas.drawBitmap(bitmapDocument!!, 0f, 0f, null)
         page.render(bitmapDocument!!, null, null, PdfRenderer.Page.RENDER_MODE_FOR_DISPLAY)
 
-        page.close()
-        renderer.close()
-        fileDescriptor.close()
+        try {
+            page.close()
+            renderer.close()
+            fileDescriptor.close()
+        } catch (ignore: Exception) {}
 
-        val bitmapSize: Int = bitmapDocument!!.byteCount
-        if (bitmapSize > MAX_BITMAP_SIZE) {
+        if (bitmapDocument!!.byteCount > MAX_BITMAP_SIZE) {
             deleteFile()
             return@withContext false
         }


### PR DESCRIPTION
Bugfixes
- Fix rare crashes during drawing of the document
- Check if document is too big to draw, retry in lower resolution and fail as a last resort
- Ignore QR code if device memory can't handle it
- Fix white screen when returning to app after while