### PR TITLE
Replace pinch to zoom image library

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -31,10 +31,10 @@ dependencies {
     implementation(libs.androidx.navigation.fragment.ktx)
     implementation(libs.androidx.navigation.ui.ktx)
     implementation(libs.androidx.preference.ktx)
-    implementation(libs.com.github.chrisbanes.photoview)
     implementation(libs.com.github.lisawray.groupie)
     implementation(libs.com.github.lisawray.groupie.viewbinding)
     implementation(libs.com.google.android.material)
+    implementation(libs.io.github.panpf.zoomimage.view)
 
     testImplementation(libs.androidx.test.ext.junit.ktx)
     testImplementation(libs.app.cash.turbine)

--- a/app/src/main/res/layout/item_pdf_page.xml
+++ b/app/src/main/res/layout/item_pdf_page.xml
@@ -49,7 +49,7 @@
             android:background="@drawable/dotted"/>
     </LinearLayout>
 
-    <com.github.chrisbanes.photoview.PhotoView
+    <com.github.panpf.zoomimage.ZoomImageView
         android:id="@+id/pdf_page"
         android:layout_width="0dp"
         android:layout_height="wrap_content"

--- a/docs/licenses/index.html
+++ b/docs/licenses/index.html
@@ -858,6 +858,29 @@
     <hr />
         <p>
             <strong>38.</strong>
+            <strong>Group:</strong> androidx.exifinterface
+            <strong>Name:</strong> exifinterface
+            <strong>Version:</strong> 1.3.6
+        </p>
+        <p>
+            <strong>POM Project URL:</strong>
+            <code>
+                <a href="https://developer.android.com/jetpack/androidx/releases/exifinterface#1.3.6">
+                    https://developer.android.com/jetpack/androidx/releases/exifinterface#1.3.6
+                </a>
+            </code>
+        </p>
+        <p>
+            <strong>POM License: Apache License, Version 2.0</strong>
+            - 
+            <a href="https://www.apache.org/licenses/LICENSE-2.0">
+                https://www.apache.org/licenses/LICENSE-2.0
+            </a>
+        </p>
+
+    <hr />
+        <p>
+            <strong>39.</strong>
             <strong>Group:</strong> androidx.fragment
             <strong>Name:</strong> fragment
             <strong>Version:</strong> 1.6.2
@@ -880,7 +903,7 @@
 
     <hr />
         <p>
-            <strong>39.</strong>
+            <strong>40.</strong>
             <strong>Group:</strong> androidx.fragment
             <strong>Name:</strong> fragment-ktx
             <strong>Version:</strong> 1.6.2
@@ -903,7 +926,7 @@
 
     <hr />
         <p>
-            <strong>40.</strong>
+            <strong>41.</strong>
             <strong>Group:</strong> androidx.interpolator
             <strong>Name:</strong> interpolator
             <strong>Version:</strong> 1.0.0
@@ -926,7 +949,7 @@
 
     <hr />
         <p>
-            <strong>41.</strong>
+            <strong>42.</strong>
             <strong>Group:</strong> androidx.legacy
             <strong>Name:</strong> legacy-support-core-utils
             <strong>Version:</strong> 1.0.0
@@ -949,7 +972,7 @@
 
     <hr />
         <p>
-            <strong>42.</strong>
+            <strong>43.</strong>
             <strong>Group:</strong> androidx.lifecycle
             <strong>Name:</strong> lifecycle-common
             <strong>Version:</strong> 2.7.0
@@ -972,7 +995,7 @@
 
     <hr />
         <p>
-            <strong>43.</strong>
+            <strong>44.</strong>
             <strong>Group:</strong> androidx.lifecycle
             <strong>Name:</strong> lifecycle-common-java8
             <strong>Version:</strong> 2.7.0
@@ -995,7 +1018,7 @@
 
     <hr />
         <p>
-            <strong>44.</strong>
+            <strong>45.</strong>
             <strong>Group:</strong> androidx.lifecycle
             <strong>Name:</strong> lifecycle-livedata
             <strong>Version:</strong> 2.7.0
@@ -1018,7 +1041,7 @@
 
     <hr />
         <p>
-            <strong>45.</strong>
+            <strong>46.</strong>
             <strong>Group:</strong> androidx.lifecycle
             <strong>Name:</strong> lifecycle-livedata-core
             <strong>Version:</strong> 2.7.0
@@ -1041,7 +1064,7 @@
 
     <hr />
         <p>
-            <strong>46.</strong>
+            <strong>47.</strong>
             <strong>Group:</strong> androidx.lifecycle
             <strong>Name:</strong> lifecycle-livedata-core-ktx
             <strong>Version:</strong> 2.7.0
@@ -1064,7 +1087,7 @@
 
     <hr />
         <p>
-            <strong>47.</strong>
+            <strong>48.</strong>
             <strong>Group:</strong> androidx.lifecycle
             <strong>Name:</strong> lifecycle-process
             <strong>Version:</strong> 2.7.0
@@ -1087,7 +1110,7 @@
 
     <hr />
         <p>
-            <strong>48.</strong>
+            <strong>49.</strong>
             <strong>Group:</strong> androidx.lifecycle
             <strong>Name:</strong> lifecycle-runtime
             <strong>Version:</strong> 2.7.0
@@ -1110,7 +1133,7 @@
 
     <hr />
         <p>
-            <strong>49.</strong>
+            <strong>50.</strong>
             <strong>Group:</strong> androidx.lifecycle
             <strong>Name:</strong> lifecycle-runtime-ktx
             <strong>Version:</strong> 2.7.0
@@ -1133,7 +1156,7 @@
 
     <hr />
         <p>
-            <strong>50.</strong>
+            <strong>51.</strong>
             <strong>Group:</strong> androidx.lifecycle
             <strong>Name:</strong> lifecycle-viewmodel
             <strong>Version:</strong> 2.7.0
@@ -1156,7 +1179,7 @@
 
     <hr />
         <p>
-            <strong>51.</strong>
+            <strong>52.</strong>
             <strong>Group:</strong> androidx.lifecycle
             <strong>Name:</strong> lifecycle-viewmodel-ktx
             <strong>Version:</strong> 2.7.0
@@ -1179,7 +1202,7 @@
 
     <hr />
         <p>
-            <strong>52.</strong>
+            <strong>53.</strong>
             <strong>Group:</strong> androidx.lifecycle
             <strong>Name:</strong> lifecycle-viewmodel-savedstate
             <strong>Version:</strong> 2.7.0
@@ -1202,7 +1225,7 @@
 
     <hr />
         <p>
-            <strong>53.</strong>
+            <strong>54.</strong>
             <strong>Group:</strong> androidx.loader
             <strong>Name:</strong> loader
             <strong>Version:</strong> 1.0.0
@@ -1225,7 +1248,7 @@
 
     <hr />
         <p>
-            <strong>54.</strong>
+            <strong>55.</strong>
             <strong>Group:</strong> androidx.localbroadcastmanager
             <strong>Name:</strong> localbroadcastmanager
             <strong>Version:</strong> 1.0.0
@@ -1248,7 +1271,7 @@
 
     <hr />
         <p>
-            <strong>55.</strong>
+            <strong>56.</strong>
             <strong>Group:</strong> androidx.navigation
             <strong>Name:</strong> navigation-common
             <strong>Version:</strong> 2.7.7
@@ -1271,7 +1294,7 @@
 
     <hr />
         <p>
-            <strong>56.</strong>
+            <strong>57.</strong>
             <strong>Group:</strong> androidx.navigation
             <strong>Name:</strong> navigation-common-ktx
             <strong>Version:</strong> 2.7.7
@@ -1294,7 +1317,7 @@
 
     <hr />
         <p>
-            <strong>57.</strong>
+            <strong>58.</strong>
             <strong>Group:</strong> androidx.navigation
             <strong>Name:</strong> navigation-fragment
             <strong>Version:</strong> 2.7.7
@@ -1317,7 +1340,7 @@
 
     <hr />
         <p>
-            <strong>58.</strong>
+            <strong>59.</strong>
             <strong>Group:</strong> androidx.navigation
             <strong>Name:</strong> navigation-fragment-ktx
             <strong>Version:</strong> 2.7.7
@@ -1340,7 +1363,7 @@
 
     <hr />
         <p>
-            <strong>59.</strong>
+            <strong>60.</strong>
             <strong>Group:</strong> androidx.navigation
             <strong>Name:</strong> navigation-runtime
             <strong>Version:</strong> 2.7.7
@@ -1363,7 +1386,7 @@
 
     <hr />
         <p>
-            <strong>60.</strong>
+            <strong>61.</strong>
             <strong>Group:</strong> androidx.navigation
             <strong>Name:</strong> navigation-runtime-ktx
             <strong>Version:</strong> 2.7.7
@@ -1386,7 +1409,7 @@
 
     <hr />
         <p>
-            <strong>61.</strong>
+            <strong>62.</strong>
             <strong>Group:</strong> androidx.navigation
             <strong>Name:</strong> navigation-ui
             <strong>Version:</strong> 2.7.7
@@ -1409,7 +1432,7 @@
 
     <hr />
         <p>
-            <strong>62.</strong>
+            <strong>63.</strong>
             <strong>Group:</strong> androidx.navigation
             <strong>Name:</strong> navigation-ui-ktx
             <strong>Version:</strong> 2.7.7
@@ -1432,7 +1455,7 @@
 
     <hr />
         <p>
-            <strong>63.</strong>
+            <strong>64.</strong>
             <strong>Group:</strong> androidx.preference
             <strong>Name:</strong> preference
             <strong>Version:</strong> 1.2.1
@@ -1455,7 +1478,7 @@
 
     <hr />
         <p>
-            <strong>64.</strong>
+            <strong>65.</strong>
             <strong>Group:</strong> androidx.preference
             <strong>Name:</strong> preference-ktx
             <strong>Version:</strong> 1.2.1
@@ -1478,7 +1501,7 @@
 
     <hr />
         <p>
-            <strong>65.</strong>
+            <strong>66.</strong>
             <strong>Group:</strong> androidx.print
             <strong>Name:</strong> print
             <strong>Version:</strong> 1.0.0
@@ -1501,7 +1524,7 @@
 
     <hr />
         <p>
-            <strong>66.</strong>
+            <strong>67.</strong>
             <strong>Group:</strong> androidx.profileinstaller
             <strong>Name:</strong> profileinstaller
             <strong>Version:</strong> 1.3.1
@@ -1524,7 +1547,7 @@
 
     <hr />
         <p>
-            <strong>67.</strong>
+            <strong>68.</strong>
             <strong>Group:</strong> androidx.recyclerview
             <strong>Name:</strong> recyclerview
             <strong>Version:</strong> 1.2.1
@@ -1547,7 +1570,7 @@
 
     <hr />
         <p>
-            <strong>68.</strong>
+            <strong>69.</strong>
             <strong>Group:</strong> androidx.resourceinspection
             <strong>Name:</strong> resourceinspection-annotation
             <strong>Version:</strong> 1.0.1
@@ -1570,7 +1593,7 @@
 
     <hr />
         <p>
-            <strong>69.</strong>
+            <strong>70.</strong>
             <strong>Group:</strong> androidx.room
             <strong>Name:</strong> room-common
             <strong>Version:</strong> 2.6.1
@@ -1593,7 +1616,7 @@
 
     <hr />
         <p>
-            <strong>70.</strong>
+            <strong>71.</strong>
             <strong>Group:</strong> androidx.room
             <strong>Name:</strong> room-ktx
             <strong>Version:</strong> 2.6.1
@@ -1616,7 +1639,7 @@
 
     <hr />
         <p>
-            <strong>71.</strong>
+            <strong>72.</strong>
             <strong>Group:</strong> androidx.room
             <strong>Name:</strong> room-runtime
             <strong>Version:</strong> 2.6.1
@@ -1639,7 +1662,7 @@
 
     <hr />
         <p>
-            <strong>72.</strong>
+            <strong>73.</strong>
             <strong>Group:</strong> androidx.savedstate
             <strong>Name:</strong> savedstate
             <strong>Version:</strong> 1.2.1
@@ -1662,7 +1685,7 @@
 
     <hr />
         <p>
-            <strong>73.</strong>
+            <strong>74.</strong>
             <strong>Group:</strong> androidx.savedstate
             <strong>Name:</strong> savedstate-ktx
             <strong>Version:</strong> 1.2.1
@@ -1685,7 +1708,7 @@
 
     <hr />
         <p>
-            <strong>74.</strong>
+            <strong>75.</strong>
             <strong>Group:</strong> androidx.slidingpanelayout
             <strong>Name:</strong> slidingpanelayout
             <strong>Version:</strong> 1.2.0
@@ -1708,7 +1731,7 @@
 
     <hr />
         <p>
-            <strong>75.</strong>
+            <strong>76.</strong>
             <strong>Group:</strong> androidx.sqlite
             <strong>Name:</strong> sqlite
             <strong>Version:</strong> 2.4.0
@@ -1731,7 +1754,7 @@
 
     <hr />
         <p>
-            <strong>76.</strong>
+            <strong>77.</strong>
             <strong>Group:</strong> androidx.sqlite
             <strong>Name:</strong> sqlite-framework
             <strong>Version:</strong> 2.4.0
@@ -1754,7 +1777,7 @@
 
     <hr />
         <p>
-            <strong>77.</strong>
+            <strong>78.</strong>
             <strong>Group:</strong> androidx.startup
             <strong>Name:</strong> startup-runtime
             <strong>Version:</strong> 1.1.1
@@ -1777,7 +1800,7 @@
 
     <hr />
         <p>
-            <strong>78.</strong>
+            <strong>79.</strong>
             <strong>Group:</strong> androidx.tracing
             <strong>Name:</strong> tracing
             <strong>Version:</strong> 1.0.0
@@ -1800,7 +1823,7 @@
 
     <hr />
         <p>
-            <strong>79.</strong>
+            <strong>80.</strong>
             <strong>Group:</strong> androidx.transition
             <strong>Name:</strong> transition
             <strong>Version:</strong> 1.4.1
@@ -1823,7 +1846,7 @@
 
     <hr />
         <p>
-            <strong>80.</strong>
+            <strong>81.</strong>
             <strong>Group:</strong> androidx.vectordrawable
             <strong>Name:</strong> vectordrawable
             <strong>Version:</strong> 1.1.0
@@ -1846,7 +1869,7 @@
 
     <hr />
         <p>
-            <strong>81.</strong>
+            <strong>82.</strong>
             <strong>Group:</strong> androidx.vectordrawable
             <strong>Name:</strong> vectordrawable-animated
             <strong>Version:</strong> 1.1.0
@@ -1869,7 +1892,7 @@
 
     <hr />
         <p>
-            <strong>82.</strong>
+            <strong>83.</strong>
             <strong>Group:</strong> androidx.versionedparcelable
             <strong>Name:</strong> versionedparcelable
             <strong>Version:</strong> 1.1.1
@@ -1892,7 +1915,7 @@
 
     <hr />
         <p>
-            <strong>83.</strong>
+            <strong>84.</strong>
             <strong>Group:</strong> androidx.viewpager
             <strong>Name:</strong> viewpager
             <strong>Version:</strong> 1.0.0
@@ -1915,7 +1938,7 @@
 
     <hr />
         <p>
-            <strong>84.</strong>
+            <strong>85.</strong>
             <strong>Group:</strong> androidx.viewpager2
             <strong>Name:</strong> viewpager2
             <strong>Version:</strong> 1.0.0
@@ -1938,7 +1961,7 @@
 
     <hr />
         <p>
-            <strong>85.</strong>
+            <strong>86.</strong>
             <strong>Group:</strong> androidx.window
             <strong>Name:</strong> window
             <strong>Version:</strong> 1.0.0
@@ -1948,29 +1971,6 @@
             <code>
                 <a href="https://developer.android.com/jetpack/androidx/releases/window#1.0.0">
                     https://developer.android.com/jetpack/androidx/releases/window#1.0.0
-                </a>
-            </code>
-        </p>
-        <p>
-            <strong>POM License: Apache License, Version 2.0</strong>
-            - 
-            <a href="https://www.apache.org/licenses/LICENSE-2.0">
-                https://www.apache.org/licenses/LICENSE-2.0
-            </a>
-        </p>
-
-    <hr />
-        <p>
-            <strong>86.</strong>
-            <strong>Group:</strong> com.github.chrisbanes
-            <strong>Name:</strong> PhotoView
-            <strong>Version:</strong> 2.3.0
-        </p>
-        <p>
-            <strong>POM Project URL:</strong>
-            <code>
-                <a href="https://baseflow.com">
-                    https://baseflow.com
                 </a>
             </code>
         </p>
@@ -2282,6 +2282,75 @@
     <hr />
         <p>
             <strong>101.</strong>
+            <strong>Group:</strong> io.github.panpf.zoomimage
+            <strong>Name:</strong> zoomimage-core
+            <strong>Version:</strong> 1.0.2
+        </p>
+        <p>
+            <strong>POM Project URL:</strong>
+            <code>
+                <a href="https://github.com/panpf/zoomimage">
+                    https://github.com/panpf/zoomimage
+                </a>
+            </code>
+        </p>
+        <p>
+            <strong>POM License: Apache License, Version 2.0</strong>
+            - 
+            <a href="https://www.apache.org/licenses/LICENSE-2.0">
+                https://www.apache.org/licenses/LICENSE-2.0
+            </a>
+        </p>
+
+    <hr />
+        <p>
+            <strong>102.</strong>
+            <strong>Group:</strong> io.github.panpf.zoomimage
+            <strong>Name:</strong> zoomimage-core-android
+            <strong>Version:</strong> 1.0.2
+        </p>
+        <p>
+            <strong>POM Project URL:</strong>
+            <code>
+                <a href="https://github.com/panpf/zoomimage">
+                    https://github.com/panpf/zoomimage
+                </a>
+            </code>
+        </p>
+        <p>
+            <strong>POM License: Apache License, Version 2.0</strong>
+            - 
+            <a href="https://www.apache.org/licenses/LICENSE-2.0">
+                https://www.apache.org/licenses/LICENSE-2.0
+            </a>
+        </p>
+
+    <hr />
+        <p>
+            <strong>103.</strong>
+            <strong>Group:</strong> io.github.panpf.zoomimage
+            <strong>Name:</strong> zoomimage-view
+            <strong>Version:</strong> 1.0.2
+        </p>
+        <p>
+            <strong>POM Project URL:</strong>
+            <code>
+                <a href="https://github.com/panpf/zoomimage">
+                    https://github.com/panpf/zoomimage
+                </a>
+            </code>
+        </p>
+        <p>
+            <strong>POM License: Apache License, Version 2.0</strong>
+            - 
+            <a href="https://www.apache.org/licenses/LICENSE-2.0">
+                https://www.apache.org/licenses/LICENSE-2.0
+            </a>
+        </p>
+
+    <hr />
+        <p>
+            <strong>104.</strong>
             <strong>Group:</strong> javax.inject
             <strong>Name:</strong> javax.inject
             <strong>Version:</strong> 1
@@ -2304,7 +2373,7 @@
 
     <hr />
         <p>
-            <strong>102.</strong>
+            <strong>105.</strong>
             <strong>Group:</strong> org.bouncycastle
             <strong>Name:</strong> bcpkix-jdk15to18
             <strong>Version:</strong> 1.78
@@ -2327,7 +2396,7 @@
 
     <hr />
         <p>
-            <strong>103.</strong>
+            <strong>106.</strong>
             <strong>Group:</strong> org.bouncycastle
             <strong>Name:</strong> bcprov-jdk15to18
             <strong>Version:</strong> 1.78
@@ -2350,7 +2419,7 @@
 
     <hr />
         <p>
-            <strong>104.</strong>
+            <strong>107.</strong>
             <strong>Group:</strong> org.bouncycastle
             <strong>Name:</strong> bcutil-jdk15to18
             <strong>Version:</strong> 1.78
@@ -2373,7 +2442,7 @@
 
     <hr />
         <p>
-            <strong>105.</strong>
+            <strong>108.</strong>
             <strong>Group:</strong> org.jetbrains
             <strong>Name:</strong> annotations
             <strong>Version:</strong> 23.0.0
@@ -2396,7 +2465,7 @@
 
     <hr />
         <p>
-            <strong>106.</strong>
+            <strong>109.</strong>
             <strong>Group:</strong> org.jetbrains.kotlin
             <strong>Name:</strong> kotlin-android-extensions-runtime
             <strong>Version:</strong> 1.9.23
@@ -2419,7 +2488,7 @@
 
     <hr />
         <p>
-            <strong>107.</strong>
+            <strong>110.</strong>
             <strong>Group:</strong> org.jetbrains.kotlin
             <strong>Name:</strong> kotlin-bom
             <strong>Version:</strong> 1.9.23
@@ -2442,7 +2511,7 @@
 
     <hr />
         <p>
-            <strong>108.</strong>
+            <strong>111.</strong>
             <strong>Group:</strong> org.jetbrains.kotlin
             <strong>Name:</strong> kotlin-parcelize-runtime
             <strong>Version:</strong> 1.9.23
@@ -2465,7 +2534,7 @@
 
     <hr />
         <p>
-            <strong>109.</strong>
+            <strong>112.</strong>
             <strong>Group:</strong> org.jetbrains.kotlin
             <strong>Name:</strong> kotlin-stdlib
             <strong>Version:</strong> 1.9.23
@@ -2488,7 +2557,30 @@
 
     <hr />
         <p>
-            <strong>110.</strong>
+            <strong>113.</strong>
+            <strong>Group:</strong> org.jetbrains.kotlin
+            <strong>Name:</strong> kotlin-stdlib-common
+            <strong>Version:</strong> 1.9.23
+        </p>
+        <p>
+            <strong>POM Project URL:</strong>
+            <code>
+                <a href="https://kotlinlang.org/">
+                    https://kotlinlang.org/
+                </a>
+            </code>
+        </p>
+        <p>
+            <strong>POM License: Apache License, Version 2.0</strong>
+            - 
+            <a href="https://www.apache.org/licenses/LICENSE-2.0">
+                https://www.apache.org/licenses/LICENSE-2.0
+            </a>
+        </p>
+
+    <hr />
+        <p>
+            <strong>114.</strong>
             <strong>Group:</strong> org.jetbrains.kotlin
             <strong>Name:</strong> kotlin-stdlib-jdk7
             <strong>Version:</strong> 1.9.23
@@ -2511,7 +2603,7 @@
 
     <hr />
         <p>
-            <strong>111.</strong>
+            <strong>115.</strong>
             <strong>Group:</strong> org.jetbrains.kotlin
             <strong>Name:</strong> kotlin-stdlib-jdk8
             <strong>Version:</strong> 1.9.23
@@ -2534,7 +2626,7 @@
 
     <hr />
         <p>
-            <strong>112.</strong>
+            <strong>116.</strong>
             <strong>Group:</strong> org.jetbrains.kotlinx
             <strong>Name:</strong> kotlinx-coroutines-android
             <strong>Version:</strong> 1.8.0
@@ -2557,7 +2649,7 @@
 
     <hr />
         <p>
-            <strong>113.</strong>
+            <strong>117.</strong>
             <strong>Group:</strong> org.jetbrains.kotlinx
             <strong>Name:</strong> kotlinx-coroutines-bom
             <strong>Version:</strong> 1.8.0
@@ -2580,7 +2672,7 @@
 
     <hr />
         <p>
-            <strong>114.</strong>
+            <strong>118.</strong>
             <strong>Group:</strong> org.jetbrains.kotlinx
             <strong>Name:</strong> kotlinx-coroutines-core
             <strong>Version:</strong> 1.8.0
@@ -2603,7 +2695,7 @@
 
     <hr />
         <p>
-            <strong>115.</strong>
+            <strong>119.</strong>
             <strong>Group:</strong> org.jetbrains.kotlinx
             <strong>Name:</strong> kotlinx-coroutines-core-jvm
             <strong>Version:</strong> 1.8.0

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,7 +16,6 @@ androidx-test-ext-junit-ktx = "1.1.5"
 androidx-test-orchestrator = "1.4.2"
 androidx-test-uiautomator = "2.3.0"
 app-cash-turbine = "1.1.0"
-com-github-chrisbanes-photoview = "2.3.0"
 com-github-jk1-dependency-license-report = "2.7"
 com-github-lisawray-groupie = "2.10.1"
 com-github-markusfisch-zxing-cpp = "2.2.0.5"
@@ -26,6 +25,7 @@ com-google-devtools-ksp = "1.9.23-1.0.20"
 com-squareup-leakcanary-android = "2.13"
 com-tom-roush-pdfbox-android = "2.0.27.0"
 io-gitlab-arturbosch-detekt = "1.23.6"
+io-github-panpf-zoomimage-view = "1.0.2"
 io-kotest-assertions-core = "5.8.1"
 io-mockk = "1.13.10"
 kotlin = "1.9.23"
@@ -54,7 +54,6 @@ androidx-test-ext-junit-ktx = { module = "androidx.test.ext:junit-ktx", version.
 androidx-test-orchestrator = { module = "androidx.test:orchestrator", version.ref = "androidx-test-orchestrator" }
 androidx-test-uiautomator = { module = "androidx.test.uiautomator:uiautomator", version.ref = "androidx-test-uiautomator" }
 app-cash-turbine = { module = "app.cash.turbine:turbine", version.ref = "app-cash-turbine" }
-com-github-chrisbanes-photoview = { module = "com.github.chrisbanes:PhotoView", version.ref = "com-github-chrisbanes-photoview" }
 com-github-lisawray-groupie = { module = "com.github.lisawray.groupie:groupie", version.ref = "com-github-lisawray-groupie" }
 com-github-lisawray-groupie-viewbinding = { module = "com.github.lisawray.groupie:groupie-viewbinding", version.ref = "com-github-lisawray-groupie" }
 com-github-markusfisch-zxing-cpp = { module = "com.github.markusfisch:zxing-cpp", version.ref = "com-github-markusfisch-zxing-cpp" }
@@ -63,6 +62,7 @@ com-google-dagger-hilt-android = { module = "com.google.dagger:hilt-android", ve
 com-google-dagger-hilt-compiler = { module = "com.google.dagger:hilt-compiler", version.ref = "com-google-dagger-hilt-android" }
 com-squareup-leakcanary-android = { module = "com.squareup.leakcanary:leakcanary-android", version.ref = "com-squareup-leakcanary-android" }
 com-tom-roush-pdfbox-android = { module = "com.tom-roush:pdfbox-android", version.ref = "com-tom-roush-pdfbox-android" }
+io-github-panpf-zoomimage-view = { module = "io.github.panpf.zoomimage:zoomimage-view", version.ref = "io-github-panpf-zoomimage-view" }
 io-kotest-assertions-core = { module = "io.kotest:kotest-assertions-core", version.ref = "io-kotest-assertions-core" }
 io-mockk = { module = "io.mockk:mockk", version.ref = "io-mockk" }
 org-bouncycastle-bcpkix-jdk15to18 = { module = "org.bouncycastle:bcpkix-jdk15to18", version.ref = "org-bouncycastle" }


### PR DESCRIPTION
- Original reason for update: Photoview library not updated for a long time
- Brings: higher maximum zoom level
- Brings: scrollbars to see where in image you are located (when zoomed in)

As requested in https://github.com/michaeltroger/greenpass-android/issues/157